### PR TITLE
Remove external_links

### DIFF
--- a/docker-compose.pa11y.yaml
+++ b/docker-compose.pa11y.yaml
@@ -7,8 +7,6 @@ services:
     restart: "no"
     command: sleep infinity
     entrypoint: ["docker-entrypoint.sh"]
-    external_links:
-      - web:${DDEV_SITENAME}.${DDEV_TLD}
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT


### PR DESCRIPTION
This PR:
* Removes external_links configuration from the pa11y service so that DDEV 1.24.10+ can start without error.

See: 
* https://github.com/Metadrop/ddev-pa11y/issues/10